### PR TITLE
Including a sample trace panel/alert log

### DIFF
--- a/simcity/gui/CityControlPanel.java
+++ b/simcity/gui/CityControlPanel.java
@@ -1,35 +1,106 @@
 package simcity.gui;
 
-import java.awt.*;
-import java.awt.event.*;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 
-import javax.swing.*;
+import javax.swing.JButton;
+import javax.swing.JPanel;
+
+import simcity.gui.trace.AlertLevel;
+import simcity.gui.trace.AlertLog;
+import simcity.gui.trace.AlertTag;
 
 public class CityControlPanel extends JPanel implements ActionListener{
-	
+
 	SimCityGui city;
 	public static final int CP_WIDTH = 1100, CP_HEIGHT = 100;
 	JButton addRestaurant, addBank;
+
+	//For managing traces
+	JButton enableInfoButton;		//You could (and probably should) substitute a JToggleButton to replace both
+	JButton disableInfoButton;		//of these, but I split it into enable and disable for clarity in the demo.
+	JButton enableRestaurantTagButton;		
+	JButton disableRestaurantTagButton;		
+	JButton enableBankTagButton;
+	JButton disableBankTagButton;
 	
+	String name = "Control Panel";
+
 	public CityControlPanel(SimCityGui city) {
 		this.city = city;
 		this.setPreferredSize(new Dimension(CP_WIDTH, CP_HEIGHT));
 		this.setVisible(true);
+
+		this.setLayout(new GridBagLayout());
+		GridBagConstraints c = new GridBagConstraints();
+		c.fill = GridBagConstraints.HORIZONTAL;
 		
 		addRestaurant = new JButton("Add Restaurant");
 		addRestaurant.addActionListener(this);
-		add(addRestaurant);
+		c.gridx = 0; c.gridy = 0;
+		add(addRestaurant, c);
 		addBank = new JButton("Add Bank");
 		addBank.addActionListener(this);
-		add(addBank);
+		c.gridx = 0; c.gridy = 1;
+		add(addBank, c);
+
+		//Trace panel buttons
+		enableInfoButton = new JButton("Show Level: INFO");
+		enableInfoButton.addActionListener(this);
+		disableInfoButton = new JButton("Hide Level: INFO");
+		disableInfoButton.addActionListener(this);
+		enableRestaurantTagButton = new JButton("Show Tag: RESTAURANT");
+		enableRestaurantTagButton.addActionListener(this);
+		disableRestaurantTagButton = new JButton("Hide Tag: RESTAURANT");
+		disableRestaurantTagButton.addActionListener(this);
+		enableBankTagButton = new JButton("Show Tag: BANK");
+		enableBankTagButton.addActionListener(this);
+		disableBankTagButton = new JButton("Hide Tag: BANK");
+		disableBankTagButton.addActionListener(this);
+		
+		c.gridx = 1; c.gridy = 0;
+		this.add(enableInfoButton, c);
+		c.gridx = 1; c.gridy = 1;
+		this.add(disableInfoButton, c);
+		c.gridx = 2; c.gridy = 0;
+		this.add(enableRestaurantTagButton, c);
+		c.gridx = 2; c.gridy = 1;
+		this.add(disableRestaurantTagButton, c);
+		c.gridx = 3; c.gridy = 0;
+		this.add(enableBankTagButton, c);
+		c.gridx = 3; c.gridy = 1;
+		this.add(disableBankTagButton, c);
 	}
-	
+
 	public void actionPerformed(ActionEvent e) {
 		if (e.getSource().equals(addRestaurant)) {
 			city.city.addObject(CityComponents.RESTAURANT);
+			AlertLog.getInstance().logInfo(AlertTag.RESTAURANT, this.name, "Adding New Restaurant");
 		}
 		else if (e.getSource().equals(addBank)) {
+			AlertLog.getInstance().logInfo(AlertTag.BANK, this.name, "Adding New Bank");
 			city.city.addObject(CityComponents.BANK);
+		}
+		else if(e.getSource().equals(enableInfoButton)) {
+			city.tracePanel.showAlertsWithLevel(AlertLevel.INFO);
+		}
+		else if(e.getSource().equals(disableInfoButton)) {
+			city.tracePanel.hideAlertsWithLevel(AlertLevel.INFO);
+		}
+		else if(e.getSource().equals(enableRestaurantTagButton)) {
+			city.tracePanel.showAlertsWithTag(AlertTag.RESTAURANT);
+		}
+		else if(e.getSource().equals(disableRestaurantTagButton)) {
+			city.tracePanel.hideAlertsWithTag(AlertTag.RESTAURANT);
+		}
+		else if(e.getSource().equals(enableBankTagButton)) {
+			city.tracePanel.showAlertsWithTag(AlertTag.BANK);
+		}
+		else if(e.getSource().equals(disableBankTagButton)) {
+			city.tracePanel.hideAlertsWithTag(AlertTag.BANK);
 		}
 	}
 }

--- a/simcity/gui/CityPanel.java
+++ b/simcity/gui/CityPanel.java
@@ -5,11 +5,17 @@ import java.awt.Dimension;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseMotionListener;
 
+import simcity.gui.trace.AlertLog;
+import simcity.gui.trace.AlertTag;
+
 public class CityPanel extends SimCityPanel implements MouseMotionListener {
 
 	public static final int CITY_WIDTH = 600, CITY_HEIGHT = 600;
 	boolean addingObject = false;
 	CityComponent temp;
+	
+	String name = "City Panel";
+	
 	public CityPanel(SimCityGui city) {
 		super(city);
 		this.setPreferredSize(new Dimension(CITY_WIDTH, CITY_HEIGHT));
@@ -39,12 +45,16 @@ public class CityPanel extends SimCityPanel implements MouseMotionListener {
 	
 	public void mousePressed(MouseEvent arg0) {
 		if (addingObject) {
+			//make sure we aren't overlapping anything
 			for (CityComponent c: statics) {
 				if (c.equals(temp))
 					continue;
-				if (c.rectangle.intersects(temp.rectangle))
+				if (c.rectangle.intersects(temp.rectangle)) {
+					AlertLog.getInstance().logError(AlertTag.GENERAL_CITY, this.name, "Can't add building, location obstructed!");
 					return;
+				}
 			}
+			AlertLog.getInstance().logInfo(AlertTag.GENERAL_CITY, this.name, "Building successfully added");
 			addingObject = false;
 			city.view.addView(new CityCard(city, Color.pink), temp.ID);
 			temp = null;
@@ -53,6 +63,7 @@ public class CityPanel extends SimCityPanel implements MouseMotionListener {
 			if (c.contains(arg0.getX(), arg0.getY())) {
 				//city.info.setText(c.ID);
 				city.view.setView(c.ID);
+				AlertLog.getInstance().logMessage(AlertTag.GENERAL_CITY, this.name, "Building Selected: " + c.ID);
 			}
 		}
 	}

--- a/simcity/gui/SimCityGui.java
+++ b/simcity/gui/SimCityGui.java
@@ -24,7 +24,9 @@ public class SimCityGui extends JFrame {
 		
 		tracePanel = new TracePanel();
 		tracePanel.setPreferredSize(new Dimension(CP.getPreferredSize().width, (int)(1.4*CP.getPreferredSize().height)));
-//		AlertLog.getInstance().addAlertListener(tracePanel);
+		tracePanel.showAlertsForAllLevels();
+		tracePanel.showAlertsForAllTags();
+
 		
 		city = new CityPanel(this);
 		

--- a/simcity/gui/SimCityGui.java
+++ b/simcity/gui/SimCityGui.java
@@ -1,8 +1,14 @@
 package simcity.gui;
 
-import java.awt.*;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.HeadlessException;
 
-import javax.swing.*;
+import javax.swing.JFrame;
+
+import simcity.gui.trace.AlertLog;
+import simcity.gui.trace.TracePanel;
 
 public class SimCityGui extends JFrame {
 	
@@ -10,10 +16,15 @@ public class SimCityGui extends JFrame {
 	InfoPanel info;
 	CityView view;
 	CityControlPanel CP;
+	TracePanel tracePanel;
 	GridBagConstraints c = new GridBagConstraints();
 
 	public SimCityGui() throws HeadlessException {
 		CP = new CityControlPanel(this);
+		
+		tracePanel = new TracePanel();
+		tracePanel.setPreferredSize(new Dimension(CP.getPreferredSize().width, (int)(1.4*CP.getPreferredSize().height)));
+//		AlertLog.getInstance().addAlertListener(tracePanel);
 		
 		city = new CityPanel(this);
 		
@@ -38,6 +49,11 @@ public class SimCityGui extends JFrame {
 		c.gridx = 0; c.gridy = 6;
 		c.gridwidth = 11; c.gridheight = 1;
 		this.add(CP, c);
+		
+		c.gridx = 0; c.gridy = 7;
+		c.gridwidth = 11; c.gridheight = 3;
+		c.fill = GridBagConstraints.BOTH;
+		this.add(tracePanel, c);
 	}
 
 	/**

--- a/simcity/gui/trace/Alert.java
+++ b/simcity/gui/trace/Alert.java
@@ -1,0 +1,53 @@
+package simcity.gui.trace;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * A class that AlertLog uses which contains all of the relevant information for a single alert.
+ * 
+ * @author Keith DeRuiter
+ * @version 2.0
+ */
+public class Alert implements Comparable<Alert> {
+	/** Used to filter alerts by {@link AlertLevel} */
+	public final AlertLevel level;
+	
+	public final AlertTag tag;
+	
+	/** Displayed in the message */
+	public final String name;
+	
+	/** The message of this alert */
+	public final String message;
+	
+	/** Timestamp of this alert */
+	public final Date date;
+
+	public Alert(AlertLevel level, AlertTag tag, String sender, String message, Date date) {
+		this.level = level;
+		this.tag = tag;
+		this.name = sender;
+		this.message = message;
+		this.date = date;
+	}
+
+	public String toString() {
+		DateFormat format = new SimpleDateFormat("HH:mm:ss");
+		if(this.level == AlertLevel.MESSAGE) {
+			return format.format(this.date) + " | (" + this.name + ") " + this.message;
+		}
+		return format.format(this.date) + " | [" + this.level + "] : (" + this.name + ") " + this.message;
+	}
+
+	@Override
+	public int compareTo(Alert a) {
+		if(!(a instanceof Alert)) {
+			throw new ClassCastException("Object being compared to is not an instance of Alert!");
+		}
+		Alert otherAlert = (Alert) a;
+		return this.date.compareTo(otherAlert.date);
+	}
+
+}

--- a/simcity/gui/trace/AlertLevel.java
+++ b/simcity/gui/trace/AlertLevel.java
@@ -1,0 +1,44 @@
+package simcity.gui.trace;
+
+/**
+ * Alert levels to be used with AlertLog. Read comments below for more
+ * information.
+ * 
+ * @author Keith DeRuiter
+ * @version 2.0
+ * 
+ */
+public enum AlertLevel {
+	
+	/** 
+	 * Error is meant to be used if you want to alert someone
+	 * about something they might be doing wrong. Of course,
+	 * limiting its use is a good idea. Errors are printed
+	 * in red.
+	 */
+	ERROR,
+	
+	/** 
+	 * Warnings are similar to errors in that you want to
+	 * alert someone else, but it isn't quite as important
+	 * as an error. Warnings are printed normally.
+	 */
+	WARNING,
+	
+	/**
+	 * Info is just excessive information someone might
+	 * want to know some day. It is generally off by default.
+	 */
+	INFO,
+
+	/**
+	 * Most alerts will have this level.  This should be the normal 
+	 * logging level for trace panel or console messages.
+	 */
+	MESSAGE,
+
+	/**
+	 * This level could be used to print specific debug information.
+	 */
+	DEBUG
+}

--- a/simcity/gui/trace/AlertListener.java
+++ b/simcity/gui/trace/AlertListener.java
@@ -1,0 +1,13 @@
+package simcity.gui.trace;
+/**
+ * An interface for being notified when an {@link Alert} occurs.
+ * @author Keith DeRuiter
+ *
+ */
+public interface AlertListener {
+	/**
+	 * Called when an alert occurs.
+	 * @param alert The alert that happened.
+	 */
+	public void alertOccurred(Alert alert);
+}

--- a/simcity/gui/trace/AlertLog.java
+++ b/simcity/gui/trace/AlertLog.java
@@ -1,0 +1,179 @@
+package simcity.gui.trace;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * This is a class designed to make it easier to send alerts and control them in
+ * a specific way without everyone climbing over each other to get print
+ * statements out there. It does this by requiring every message to have a tag
+ * associated with it. The default are ERROR, WARNING, or INFO, but you can add
+ * any you want. The nice part is that you can control which tags actually get
+ * printed to the console and which simply get put on to a list.
+ * 
+ * @author Keith DeRuiter
+ * @version 2.0
+ * 
+ * @see Alert
+ * @see AlertListener
+ * @see AlertLevel
+ */
+public class AlertLog {
+
+	private static AlertLog instance = new AlertLog();
+	private List<AlertListener> registeredAlertListeners;
+
+	/**
+	 * The list of {@link AlertLevel} that will print to the System.out/err console when added to the Log.
+	 * Defaults to every level printing.
+	 */
+	private Set<AlertLevel> printedAlertLevels = Collections.synchronizedSet(EnumSet.allOf(AlertLevel.class));
+	private List<Alert> alerts = Collections.synchronizedList(new ArrayList<Alert>());
+	
+
+	/**
+	 * Private constructor to make AlertLog a singleton, creates a list to hold all alert listeners.
+	 * Also sets the default printed types to be errors, warnings, and messages.
+	 */
+	private AlertLog() {
+//		this.printedAlertLevels.add(AlertLevel.ERROR);
+//		this.printedAlertLevels.add(AlertLevel.WARNING);
+		this.registeredAlertListeners = Collections.synchronizedList(new ArrayList<AlertListener>());
+	}
+	
+	/**
+	 * Gets the one instance of the AlertLog singleton.
+	 * @return The one singleton instance of AlertLog.
+	 */
+	public static AlertLog getInstance() {
+		return AlertLog.instance;
+	}
+
+	/**
+	 * Logs an error.
+	 * @param tag the {@link AlertTag} saying what group type this alert is tagged as.
+	 * @param name The name of the thing sending this alert.
+	 * @param message The message of this alert.
+	 */
+	public void logError(AlertTag tag, String name, String message) {
+		this.sendAlert(AlertLevel.ERROR, tag, name, message);
+	}
+	
+	/**
+	 * Logs a warning.
+	 * @param tag the {@link AlertTag} saying what group type this alert is tagged as.
+	 * @param name The name of the thing sending this alert.
+	 * @param message The message of this alert.
+	 */
+	public void logWarning(AlertTag tag, String name, String message) {
+		this.sendAlert(AlertLevel.WARNING, tag, name, message);
+	}
+	
+	/**
+	 * Logs info.
+	 * @param tag the {@link AlertTag} saying what group type this alert is tagged as.
+	 * @param name The name of the thing sending this alert.
+	 * @param message The message of this alert.
+	 */
+	public void logInfo(AlertTag tag, String name, String message) {
+		this.sendAlert(AlertLevel.INFO, tag, name, message);
+	}
+	
+	/**
+	 * Logs a message.
+	 * @param tag the {@link AlertTag} saying what group type this alert is tagged as.
+	 * @param name The name of the thing sending this alert.
+	 * @param message The message of this alert.
+	 */
+	public void logMessage(AlertTag tag, String name, String message) {
+		this.sendAlert(AlertLevel.MESSAGE, tag, name, message);
+	}
+	
+	/**
+	 * Logs a debug alert.
+	 * @param tag the {@link AlertTag} saying what group type this alert is tagged as.
+	 * @param name The name of the thing sending this alert.
+	 * @param message The message of this alert.
+	 */
+	public void logDebug(AlertTag tag, String name, String message) {
+		this.sendAlert(AlertLevel.MESSAGE, tag, name, message);
+	}
+	
+	
+	/**
+	 * Send an alert to the log.
+	 * 
+	 * @param level The {@link AlertLevel} to log this message with.
+	 * @param tag the {@link AlertTag} saying what group type this alert is tagged as.
+	 * @param name The name of the thing sending this alert 
+	 * @param message The message to be logged.
+	 */
+	public void sendAlert(AlertLevel level, AlertTag tag, String name, String message) {		
+//		StackTraceElement[] s = new RuntimeException().getStackTrace();
+//		String className = s[1].getClassName();
+
+//		String senderClassName = new Throwable().getStackTrace()[1].getClassName();
+
+		Date date = new Date();	//Timestamp
+
+		//Make the alert.  Also prints to std out/err.
+		Alert alert = new Alert(level, tag, name, message, date);
+		if (this.printedAlertLevels.contains(level)) {
+			if (level == AlertLevel.ERROR) {
+				System.err.println(alert);
+			} else {
+				System.out.println(alert);
+			}
+		}
+		this.alerts.add(alert);
+		
+		//Notify all people who have told me they want to listen for alerts.
+		for(AlertListener al:this.registeredAlertListeners) {
+			al.alertOccurred(alert);
+		}
+	}
+
+	/**
+	 * Enable an AlertLevel to the list of types that are printed to the console when an alert is made.
+	 * If it is already on the list nothing will change.  <br><br>
+	 * NOTE: This only controls printing to the
+	 * standard console at the time an alert is generated.
+	 * 
+	 * @param type
+	 */
+	public void enableAlertLevel(AlertLevel type) {
+		this.printedAlertLevels.add(type);
+	}
+
+	/**
+	 * Disable an AlertType from the list of types that are printed to the console when an alert is made.
+	 * If it is not on the list nothing will change.  <br><br>
+	 * NOTE: This only controls printing to the
+	 * standard System.out/System.err console at the time an alert is generated.
+	 * 
+	 * @param type
+	 */
+	public void disableAlertLevel(AlertLevel type) {
+		this.printedAlertLevels.remove(type);
+	}
+
+	/**
+	 * Get a copy of the list of all the alerts the AlertLog has collected.
+	 * 
+	 * @return The list of all {@link Alert}s. 
+	 */
+	public List<Alert> getAlerts() {
+		return new ArrayList<Alert>(this.alerts);
+	}
+	
+	/**
+	 * Registers someone to be notified when an alert is added.
+	 * @param alertListener the listener to register.
+	 */
+	public void addAlertListener(AlertListener alertListener) {
+		this.registeredAlertListeners.add(alertListener);
+	}
+}

--- a/simcity/gui/trace/AlertLog.java
+++ b/simcity/gui/trace/AlertLog.java
@@ -23,7 +23,10 @@ import java.util.Set;
  */
 public class AlertLog {
 
+	/** Holds the single AlertLog instance. */
 	private static AlertLog instance = new AlertLog();
+	
+	/** List of all {@link AlertListeners} that should be notified when an alert occurs. */
 	private List<AlertListener> registeredAlertListeners;
 
 	/**
@@ -31,6 +34,8 @@ public class AlertLog {
 	 * Defaults to every level printing.
 	 */
 	private Set<AlertLevel> printedAlertLevels = Collections.synchronizedSet(EnumSet.allOf(AlertLevel.class));
+	
+	/** The list of all the Alerts. */
 	private List<Alert> alerts = Collections.synchronizedList(new ArrayList<Alert>());
 	
 
@@ -53,7 +58,7 @@ public class AlertLog {
 	}
 
 	/**
-	 * Logs an error.
+	 * Logs an error using {@link #sendAlert}.
 	 * @param tag the {@link AlertTag} saying what group type this alert is tagged as.
 	 * @param name The name of the thing sending this alert.
 	 * @param message The message of this alert.
@@ -63,7 +68,7 @@ public class AlertLog {
 	}
 	
 	/**
-	 * Logs a warning.
+	 * Logs a warning using {@link #sendAlert}.
 	 * @param tag the {@link AlertTag} saying what group type this alert is tagged as.
 	 * @param name The name of the thing sending this alert.
 	 * @param message The message of this alert.
@@ -73,7 +78,7 @@ public class AlertLog {
 	}
 	
 	/**
-	 * Logs info.
+	 * Logs info using {@link #sendAlert}.
 	 * @param tag the {@link AlertTag} saying what group type this alert is tagged as.
 	 * @param name The name of the thing sending this alert.
 	 * @param message The message of this alert.
@@ -83,7 +88,7 @@ public class AlertLog {
 	}
 	
 	/**
-	 * Logs a message.
+	 * Logs a message using {@link #sendAlert}.
 	 * @param tag the {@link AlertTag} saying what group type this alert is tagged as.
 	 * @param name The name of the thing sending this alert.
 	 * @param message The message of this alert.
@@ -93,7 +98,7 @@ public class AlertLog {
 	}
 	
 	/**
-	 * Logs a debug alert.
+	 * Logs a debug alert using {@link #sendAlert}.
 	 * @param tag the {@link AlertTag} saying what group type this alert is tagged as.
 	 * @param name The name of the thing sending this alert.
 	 * @param message The message of this alert.

--- a/simcity/gui/trace/AlertLog.java
+++ b/simcity/gui/trace/AlertLog.java
@@ -174,6 +174,9 @@ public class AlertLog {
 	 * @param alertListener the listener to register.
 	 */
 	public void addAlertListener(AlertListener alertListener) {
-		this.registeredAlertListeners.add(alertListener);
+		if(registeredAlertListeners.contains(alertListener)) {
+			return;
+		}
+		registeredAlertListeners.add(alertListener);
 	}
 }

--- a/simcity/gui/trace/AlertTag.java
+++ b/simcity/gui/trace/AlertTag.java
@@ -16,5 +16,8 @@ public enum AlertTag {
 	PERSON,
 	BANK_TELLER,
 	BANK_CUSTOMER,
-	BUS_STOP
+	BUS_STOP,
+	RESTAURANT,		//For the demo code where you make a new restaurant
+	BANK,			//For the demo code where you make a new bank
+	GENERAL_CITY
 }

--- a/simcity/gui/trace/AlertTag.java
+++ b/simcity/gui/trace/AlertTag.java
@@ -1,0 +1,20 @@
+package simcity.gui.trace;
+
+/**
+ * These enums represent tags that group alerts together.  <br><br>
+ * 
+ * This is a separate idea from the {@link AlertLevel}.
+ * A tag would group all messages from a similar source.  Examples could be: BANK_TELLER, RESTAURANT_ONE_WAITER,
+ * or PERSON.  This way, the trace panel can sort through and identify all of the alerts generated in a specific group.
+ * The trace panel then uses this information to decide what to display, which can be toggled.  You could have all of
+ * the bank tellers be tagged as a "BANK_TELLER" group so you could turn messages from tellers on and off.
+ * 
+ * @author Keith DeRuiter
+ *
+ */
+public enum AlertTag {
+	PERSON,
+	BANK_TELLER,
+	BANK_CUSTOMER,
+	BUS_STOP
+}

--- a/simcity/gui/trace/DemoLauncher.java
+++ b/simcity/gui/trace/DemoLauncher.java
@@ -1,0 +1,328 @@
+package simcity.gui.trace;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.util.ArrayList;
+import java.util.Timer;
+import java.util.TimerTask;
+
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+
+/**
+ * A quick demo of some squares moving around and logging when they change color zones.  You can also
+ * click the mouse in either color to generate a different kind of message. <br><br>
+ * 
+ * TUTORIAL: You can search through this file for the word "TUTORIAL" to see relevant pieces of 
+ * code with instructions on how to use the {@link AlertLog} and {@link TracePanel}.
+ * 
+ * @author Keith DeRuiter
+ *
+ */
+@SuppressWarnings("serial")
+public class DemoLauncher extends JFrame {
+
+	AnimPanel animationPanel;
+	ControlPanel controlPanel;
+	
+	//============================ TUTORIAL ==========================================
+	//You declare a TracePanel just like any other variable, and it extends JPanel, so you use
+	//it in the same way.
+	TracePanel tracePanel;
+	//================================================================================
+
+
+	public DemoLauncher() {
+		this.animationPanel = new AnimPanel();
+		this.tracePanel = new TracePanel();
+		this.controlPanel = new ControlPanel(tracePanel);
+		tracePanel.setPreferredSize(new Dimension(800, 300));
+		
+		this.setLayout(new BorderLayout());
+		this.add(animationPanel, BorderLayout.CENTER);
+		this.add(controlPanel, BorderLayout.EAST);
+		this.add(tracePanel, BorderLayout.SOUTH);
+	}
+
+	public void start() {
+		Timer t = new Timer();
+		t.scheduleAtFixedRate(new TimerTask() {
+			@Override
+			public void run() {
+				animationPanel.update();		//Moves demo shapes around				
+				repaint();
+			}
+		}, 0, 10);
+		
+		//============================ TUTORIAL ==========================================
+		//We have to tell the trace panel what kinds of messages to display.  Here we say to display
+		//normal MESSAGEs tagged with the PERSON tag (the type I use in this demo).  You can also 
+		//hide messages of certain Levels, or messages tagged a certain way (eg. Don't show anything
+		//that says it is from a MARKET_EMPLOYEE).  Here we decide to hide debug messages and things
+		//tagged as AlertTag.BUS_STOP
+		tracePanel.showAlertsWithLevel(AlertLevel.ERROR);		//THESE PRINT RED, WARNINGS PRINT YELLOW on a black background... :/
+		tracePanel.showAlertsWithLevel(AlertLevel.INFO);		//THESE PRINT BLUE
+		tracePanel.showAlertsWithLevel(AlertLevel.MESSAGE);		//THESE SHOULD BE THE MOST COMMON AND PRINT BLACK
+		
+		tracePanel.hideAlertsWithLevel(AlertLevel.DEBUG);
+		
+		tracePanel.showAlertsWithTag(AlertTag.PERSON);
+		tracePanel.showAlertsWithTag(AlertTag.BANK_CUSTOMER);
+		
+		tracePanel.hideAlertsWithTag(AlertTag.BUS_STOP);
+		//
+		//You will have to add your own AlertTag types to the AlertTag enum for your project.
+		//================================================================================
+	
+		//============================ TUTORIAL ==========================================
+		//We need to let the log know that the trace panel wants to listen for alert messages.
+		//This is how the trace panel will be automatically told when anyone logs a message, and 
+		//will store or display it as appropriate.  Note how we are accessing the AlertLog: using
+		//the fact that it is a globally accessible singleton (there is only ever ONE log, and 
+		//everybody accesses the same one).
+		AlertLog.getInstance().addAlertListener(tracePanel);
+		//================================================================================		
+	}
+
+	
+	//CLASS TO DISPLAY THIS SIMPLE ANIMATION
+	private class AnimPanel extends JPanel implements MouseListener {
+
+		//Just used to hold the thing i'm moving around
+		private class Thing extends Point { 
+			String name;
+			int dx = 1;
+			boolean inRed = true;
+			
+			public Thing(String name, int yPos) {
+				this.name = name;
+				this.y = yPos;
+			}
+
+			public void move() {
+				if(this.x > 500) {	//Go left
+					dx = -2;
+				} else if(this.x < 200) {	//Go right
+					dx = 2;
+				}
+				this.x += dx;
+			}
+		}
+
+		ArrayList<Thing> things = new ArrayList<>();
+
+		Rectangle redArea;
+		Rectangle blueArea;
+
+		public AnimPanel() {
+			things.add(new Thing("Thing One", 150));
+			things.add(new Thing("Thing Two", 300));
+			things.get(0).x = 350;
+			
+			//everything stays 0 b/c window isn't visible yet...
+			redArea = new Rectangle(0, 0, this.getWidth()/2, this.getHeight());
+			blueArea = new Rectangle(this.getWidth()/2, 0, this.getWidth(), this.getHeight());
+			
+			this.addMouseListener(this);
+		}
+
+		public void update() {
+			//Big hack to keep rect values current
+			redArea = new Rectangle(0, 0, this.getWidth()/2, this.getHeight());
+			blueArea = new Rectangle(this.getWidth()/2, 0, this.getWidth(), this.getHeight());
+			
+			for(Thing t : things) {
+				t.move();
+				if(redArea.contains(t) && !t.inRed) {
+					t.inRed = true;
+					
+					//============================ TUTORIAL ==========================================
+					//THIS IS HOW YOU SEND THINGS TO THE ALERT LOG, WHICH THE TRACE PANEL READS
+					//Note that we are using the logInfo() method to specify that this is a normal MESSAGE,
+					//as opposed to an INFO message, or an ERROR/WARNING.  We send the name of the "person"
+					//as well, and that will be printed out automatically.
+					AlertLog.getInstance().logMessage(AlertTag.PERSON, t.name, "I am in the RED ZONE!");
+					//================================================================================
+				}
+				if(blueArea.contains(t) && t.inRed) {
+					t.inRed = false;
+					
+					//============================ TUTORIAL ==========================================
+					//THIS IS HOW YOU SEND THINGS TO THE ALERT LOG, WHICH THE TRACE PANEL READS
+					//Note that we are using the logInfo() method to specify that this is a normal MESSAGE,
+					//as opposed to an INFO message, or an ERROR/WARNING.  We send the name of the "person"
+					//as well, and that will be printed out automatically.
+					AlertLog.getInstance().logMessage(AlertTag.PERSON, t.name, "I am in the blue zone...");					
+					//================================================================================
+				}
+			}
+		}
+
+		@Override
+		protected void paintComponent(Graphics g) {
+			super.paintComponent(g);
+			Graphics2D g2d = (Graphics2D) g;
+						
+			g2d.setColor(Color.RED);
+			g2d.fillRect(redArea.x, redArea.y, this.getWidth(), this.getHeight());
+			g2d.setColor(Color.BLUE);
+			g2d.fillRect(blueArea.x, blueArea.y, this.getWidth(), this.getHeight());
+			
+			g2d.setColor(Color.GREEN);
+			for(Thing thing : things) {
+				g2d.fillRect(thing.x, thing.y, 20, 20);
+			}
+		}
+
+
+		@Override
+		public void mousePressed(MouseEvent e) {
+			if(redArea.contains(e.getPoint())) {
+				//============================ TUTORIAL ==========================================
+				//THIS IS HOW YOU SEND THINGS TO THE ALERT LOG, WHICH THE TRACE PANEL READS
+				//Note that we are using the logMessage() method to specify that this is an INFO message,
+				//as opposed to a normal message, or an ERROR/WARNING.  Here we are telling it to log with the 
+				//tag: BANK_CUSTOMER from a sender called "Mouse".
+				AlertLog.getInstance().logInfo(AlertTag.BANK_CUSTOMER, "Mouse", "You clicked the RED ZONE!");
+				//================================================================================
+			}
+			if(blueArea.contains(e.getPoint())) {
+				//============================ TUTORIAL ==========================================
+				//Note that we are using the logMessage() method to specify that this is an ERROR message,
+				//as opposed to INFO, or WARNING, etc.  Here we are telling it to log with the 
+				//tag: BANK_CUSTOMER from a sender called "Mouse".
+				//Notice the different methods to log different Levels of messages.  There are methods to 
+				//logError, logWarning, logInfo, logMessage, and logDebug that you should use. 
+				AlertLog.getInstance().logError(AlertTag.BANK_CUSTOMER, "Mouse", "You clicked the blue zone");
+				//================================================================================
+			}
+		}
+
+		@Override
+		public void mouseReleased(MouseEvent e) {}
+		@Override
+		public void mouseClicked(MouseEvent e) {}
+		@Override
+		public void mouseEntered(MouseEvent e) {}
+		@Override
+		public void mouseExited(MouseEvent e) {}
+	}
+
+	
+	//CONTROL PANEL CLASS
+	private class ControlPanel extends JPanel {
+		TracePanel tp;	//Hack so I can easily call showAlertsWithLevel for this demo.
+		
+		JButton enableMessagesButton;		//You could (and probably should) substitute a JToggleButton to replace both
+		JButton disableMessagesButton;		//of these, but I split it into enable and disable for clarity in the demo.
+		JButton enableErrorButton;		
+		JButton disableErrorButton;		
+		JButton enableBankCustTagButton;		//You could (and probably should) substitute a JToggleButton to replace both
+		JButton disableBankCustTagButton;		//of these, but I split it into enable and disable for clarity in the demo.
+		
+		public ControlPanel(final TracePanel tracePanel) {
+			this.tp = tracePanel;
+			enableMessagesButton = new JButton("Show Level: MESSAGE");
+			disableMessagesButton = new JButton("Hide Level: MESSAGE");
+			enableErrorButton = new JButton("Show Level: ERROR");
+			disableErrorButton = new JButton("Hide Level: ERROR");
+			enableBankCustTagButton = new JButton("Show Tag: BANK_CUSTOMER");
+			disableBankCustTagButton = new JButton("Hide Tag: BANK_CUSTOMER");
+			
+			
+			enableMessagesButton.addActionListener(new ActionListener() {
+				@Override
+				public void actionPerformed(ActionEvent e) {
+					//============================ TUTORIAL ==========================================
+					//This is how you make messages with a certain Level (normal MESSAGE here) show up in the trace panel.
+					tracePanel.showAlertsWithLevel(AlertLevel.MESSAGE);
+					//================================================================================
+				}
+			});
+			disableMessagesButton.addActionListener(new ActionListener() {
+				@Override
+				public void actionPerformed(ActionEvent e) {
+					//============================ TUTORIAL ==========================================
+					//This is how you make messages with a certain Level not show up in the trace panel.
+					tracePanel.hideAlertsWithLevel(AlertLevel.MESSAGE);
+					//================================================================================
+				}
+			});
+			enableErrorButton.addActionListener(new ActionListener() {
+				@Override
+				public void actionPerformed(ActionEvent e) {
+					//============================ TUTORIAL ==========================================
+					//This is how you make messages with a level of ERROR show up in the trace panel.
+					tracePanel.showAlertsWithLevel(AlertLevel.ERROR);
+					//================================================================================
+				}
+			});
+			disableErrorButton.addActionListener(new ActionListener() {
+				@Override
+				public void actionPerformed(ActionEvent e) {
+					//============================ TUTORIAL ==========================================
+					//This is how you make messages with a level of ERROR not show up in the trace panel.
+					tracePanel.hideAlertsWithLevel(AlertLevel.ERROR);
+					//================================================================================
+				}
+			});
+			enableBankCustTagButton.addActionListener(new ActionListener() {
+				@Override
+				public void actionPerformed(ActionEvent e) {
+					//============================ TUTORIAL ==========================================
+					//This works the same way as AlertLevels, only you're using tags instead.
+					//In this demo, I generate message with tag BANK_CUSTOMER when you click in the 
+					//AnimationPanel somewhere.
+					tracePanel.showAlertsWithTag(AlertTag.BANK_CUSTOMER);
+					//================================================================================
+				}
+			});
+			disableBankCustTagButton.addActionListener(new ActionListener() {
+				@Override
+				public void actionPerformed(ActionEvent e) {
+					//============================ TUTORIAL ==========================================
+					//This works the same way as AlertLevels, only you're using tags instead.
+					tracePanel.hideAlertsWithTag(AlertTag.BANK_CUSTOMER);
+					//================================================================================
+				}
+			});
+			this.setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+			this.add(enableMessagesButton);
+			this.add(disableMessagesButton);
+			this.add(enableErrorButton);
+			this.add(disableErrorButton);
+			this.add(enableBankCustTagButton);
+			this.add(disableBankCustTagButton);
+			this.setMinimumSize(new Dimension(50, 600));
+		}
+	}
+	
+	
+	/**
+	 * Launch the demo.
+	 * @param args
+	 */
+	public static void main(String[] args) {
+		DemoLauncher dl = new DemoLauncher();
+		dl.setTitle("Trace Panel Demo");
+		dl.setDefaultCloseOperation(EXIT_ON_CLOSE);
+		dl.setPreferredSize(new Dimension(900, 700));
+		dl.setMinimumSize(new Dimension(900, 700));
+		dl.setResizable(false);
+		dl.setVisible(true);
+
+		dl.start();
+	}
+
+}

--- a/simcity/gui/trace/DemoLauncher.java
+++ b/simcity/gui/trace/DemoLauncher.java
@@ -83,6 +83,9 @@ public class DemoLauncher extends JFrame {
 		tracePanel.hideAlertsWithTag(AlertTag.BUS_STOP);
 		//
 		//You will have to add your own AlertTag types to the AlertTag enum for your project.
+		//There are two helper methods that enable all AlertLevels and all AlertTags that you can use
+		//if you don't want to manually enable them all.  IF NOTHING APPEARS, CHECK THAT YOU HAVE 
+		//THE RIGHT LEVELS AND TAGS TURNED ON.  That will likely be the most common problem.
 		//================================================================================
 	
 		//============================ TUTORIAL ==========================================

--- a/simcity/gui/trace/TracePanel.java
+++ b/simcity/gui/trace/TracePanel.java
@@ -21,7 +21,7 @@ import javax.swing.text.StyledDocument;
 
 /**
  * The class for managing and displaying the message traces from the factory/simcity. To be used as an 
- * {@link AlertListener} with {@link AlertLog}.  <br><br>
+ * {@link AlertListener} with {@link AlertLog}.  By default, ALL LEVELS AN NO TAGS ARE ENABLED!  <br><br>
  * 
  * When printing, the {@link AlertLevel} AND the {@link AlertTag} must be enabled to see a message.  This means that 
  * if only ERROR and INFO levels are enabled, and someone with a tag BANK_TELLER 
@@ -46,8 +46,8 @@ public class TracePanel extends JScrollPane implements AlertListener {
 	private JTextPane traceTextPane;
 
 	private List<Alert> newAlerts = Collections.synchronizedList(new ArrayList<Alert>());
-	private Set<AlertLevel> visibleLevels = Collections.synchronizedSet(EnumSet.noneOf(AlertLevel.class));
-	private Set<AlertTag> visibleTags = Collections.synchronizedSet(EnumSet.noneOf(AlertTag.class));
+	private Set<AlertLevel> visibleLevels = Collections.synchronizedSet(EnumSet.allOf(AlertLevel.class));
+	private Set<AlertTag> visibleTags = Collections.synchronizedSet(EnumSet.allOf(AlertTag.class));
 
 	Dimension size;
 	Style errorStyle;
@@ -91,11 +91,15 @@ public class TracePanel extends JScrollPane implements AlertListener {
 		StyleConstants.setForeground(defaultStyle, Color.black);
 
 
-		//Set the default visible levels
+		//Set the default visible levels, redundant with the EnumSet declaration above
 		visibleLevels.add(AlertLevel.MESSAGE);
 		visibleLevels.add(AlertLevel.ERROR);
 		visibleLevels.add(AlertLevel.WARNING);
 		visibleLevels.add(AlertLevel.INFO);
+		visibleLevels.add(AlertLevel.DEBUG);
+		
+		//Sets up the TracePanel to automatically be tied with the AlertLog.
+		AlertLog.getInstance().addAlertListener(this);
 	}
 
 	

--- a/simcity/gui/trace/TracePanel.java
+++ b/simcity/gui/trace/TracePanel.java
@@ -1,0 +1,253 @@
+package simcity.gui.trace;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.swing.JScrollPane;
+import javax.swing.JTextPane;
+import javax.swing.border.BevelBorder;
+import javax.swing.border.EtchedBorder;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import javax.swing.text.Style;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.StyledDocument;
+
+
+/**
+ * The class for managing and displaying the message traces from the factory/simcity. To be used as an 
+ * {@link AlertListener} with {@link AlertLog}.  <br><br>
+ * 
+ * When printing, the {@link AlertLevel} AND the {@link AlertTag} must be enabled to see a message.  This means that 
+ * if only ERROR and INFO levels are enabled, and someone with a tag BANK_TELLER 
+ * (presumably tagged on all of the messages any bank tellers send) sends an ERROR, a WARNING, and an INFO message,
+ * then the only ones that will appear are the ERROR and INFO.  You would have to re-enable the WARNING AlertLevel
+ * (which filters and updates the trace panel) to see those messages., even if the tag for BANK_TELLER were enabled 
+ * the whole time.  Similarly, if WARNING Level is enabled, but PERSON Tag messages are being hidden, then if a 
+ * WARNING message comes through with a tag of PERSON, it won't display because person messages aren't visible. <br><br>
+ * 
+ * If you wish to customize that behavior, then look at the {@link TracePanel#isAlertVisible(Alert)} method.
+ * 
+ * @author Keith DeRuiter
+ * @version 2.0
+ * 
+ * @see AlertLog
+ * @see AlertLevel
+ * @see AlertTag
+ */
+public class TracePanel extends JScrollPane implements AlertListener {
+
+	private static final long serialVersionUID = 5643932617391465416L;
+	private JTextPane traceTextPane;
+
+	private List<Alert> newAlerts = Collections.synchronizedList(new ArrayList<Alert>());
+	private Set<AlertLevel> visibleLevels = Collections.synchronizedSet(EnumSet.noneOf(AlertLevel.class));
+	private Set<AlertTag> visibleTags = Collections.synchronizedSet(EnumSet.noneOf(AlertTag.class));
+
+	Dimension size;
+	Style errorStyle;
+	Style warningStyle;
+	Style infoStyle;
+	Style defaultStyle;
+
+	public TracePanel() {
+		super();
+		this.setBorder(new BevelBorder(EtchedBorder.LOWERED));
+		this.size = new Dimension(500, 100);
+		traceTextPane = new JTextPane();
+		traceTextPane.setEditable(false);
+		traceTextPane.setPreferredSize(size);
+		// this.add(traceTextPane);
+		this.setViewportView(traceTextPane);
+
+		this.setPreferredSize(size);
+		this.setEnabled(true);
+
+		//Set up the styled doc and styles to use for printing
+		StyledDocument styledDoc = traceTextPane.getStyledDocument();
+
+		// Create a style object and then set the style attributes
+		errorStyle = styledDoc.addStyle("ErrorStyle", null);
+		warningStyle = styledDoc.addStyle("WarningStyle", null);
+		infoStyle = styledDoc.addStyle("InfoStyle", null);
+		defaultStyle = styledDoc.addStyle("DefaultStyle", null);
+
+		// Error
+		StyleConstants.setForeground(errorStyle, Color.red);
+
+		// Warning
+		StyleConstants.setForeground(warningStyle, Color.yellow);
+		StyleConstants.setBackground(warningStyle, Color.black);		//TODO: This looks ugly and is only so we could actually read the text... change it!
+
+		// Info
+		StyleConstants.setForeground(infoStyle, Color.blue);
+
+		// Default
+		StyleConstants.setForeground(defaultStyle, Color.black);
+
+
+		//Set the default visible levels
+		visibleLevels.add(AlertLevel.MESSAGE);
+		visibleLevels.add(AlertLevel.ERROR);
+		visibleLevels.add(AlertLevel.WARNING);
+		visibleLevels.add(AlertLevel.INFO);
+	}
+
+	
+	/**
+	 * Determines if a given alert should be displayed based on all of the currently enabled {@link AlertLevel}
+	 * and {@link AlertTag} parameters.
+	 * @param alert The alert to check.
+	 * @return true if the alert should be visible, false otherwise.
+	 * 
+	 * @see {@link #showAlertsWithLevel(AlertLevel)}
+	 * @see {@link #hideAlertsWithLevel(AlertLevel)}
+	 * @see {@link #showAlertsWithTag(AlertTag)}
+	 * @see {@link #hideAlertsWithTag(AlertTag)}
+	 */
+	private boolean isAlertVisible(Alert alert) {
+		if(visibleLevels.contains(alert.level) && visibleTags.contains(alert.tag)) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * Updates the trace panel to include all new messages from the log, 
+	 */
+	private void updateTracePanel() {
+		synchronized (newAlerts) {
+			for (Alert alert : newAlerts) {
+				try {
+					if(!isAlertVisible(alert)) {	//If not visible, skip this alert in the loop
+						continue;
+					}
+
+					//Pick a style to print with
+					Style styleToPrint = null;
+					switch (alert.level) {
+					case ERROR:
+						styleToPrint = errorStyle;
+						break;
+					case WARNING:
+						styleToPrint = warningStyle;
+						break;
+					case INFO:
+						styleToPrint = infoStyle;
+						break;
+					default:
+						styleToPrint = defaultStyle;
+						break;
+					}
+
+					//Insert the alert into the panel's document
+					int endPosition = traceTextPane.getDocument().getEndPosition().getOffset();
+					traceTextPane.getStyledDocument().insertString(endPosition, alert.toString() + "\n", styleToPrint);
+					
+				} catch (BadLocationException e) {
+					e.printStackTrace();
+				}
+			}
+			newAlerts.clear();	//We've dealt with the new alerts, so remove them form the new alerts list.
+		}
+	}
+
+	/**
+	 * Filters the trace panel according to Level and Tag and only displays those which have been enabled.
+	 */
+	private void filterTracePanel() {
+		updateTracePanel();	//update the panel to make sure we have the most recent
+
+		try {
+			traceTextPane.getStyledDocument().remove(0, traceTextPane.getStyledDocument().getLength());	//Removes the whole document
+		} catch (BadLocationException e) {
+			e.printStackTrace();
+		}
+		
+		List<Alert> alerts = AlertLog.getInstance().getAlerts();	//Get all the alerts from the log
+		Collections.sort(alerts);									//Sort them (they end up sorted by timestamp)
+		for(Alert alert:alerts) {
+			if(visibleTags.contains(alert.tag) && visibleLevels.contains(alert.level)) {
+				newAlerts.add(alert);
+				//System.out.println("Adding Alert: " + alert.name + alert.level + alert.tag);
+			}
+		}
+
+		updateTracePanel();	//update the panel to now reflect the correct alerts
+	}
+
+	/**
+	 * Makes Alerts with a given {@link AlertLevel} show up in the trace panel.
+	 * @param level The level whose alerts you do want to see.
+	 */
+	public void showAlertsWithLevel(AlertLevel level) {
+		this.visibleLevels.add(level);
+		filterTracePanel();
+	}
+	/**
+	 * Makes Alerts with a given {@link AlertLevel} not show up in the trace panel.
+	 * @param level The level whose alerts you don't want to see.
+	 */
+	public void hideAlertsWithLevel(AlertLevel level) {
+		this.visibleLevels.remove(level);
+		filterTracePanel();
+	}
+
+	/**
+	 * Makes Alerts with a given {@link AlertTag} show up in the trace panel.
+	 * @param tag The tag whose alerts you do want to see.
+	 */
+	public void showAlertsWithTag(AlertTag tag) {
+		this.visibleTags.add(tag);
+		filterTracePanel();
+	}
+
+	/**
+	 * Makes Alerts with a given {@link AlertTag} not show up in the trace panel.
+	 * @param tag The tag whose alerts you don't want to see.
+	 */
+	public void hideAlertsWithTag(AlertTag tag) {
+		this.visibleTags.remove(tag);
+		filterTracePanel();
+	}
+
+	/**
+	 * Adds a new {@link Alert} to the trace panel.
+	 * @param alert The alert that is being added.
+	 */
+	public void addNewAlert(Alert alert) {
+		//This should make it only scroll down if we are already at the bottom.  Like a scroll lock kinda thing.
+		boolean scrollDown = (this.getVerticalScrollBar().getValue() + this
+				.getVerticalScrollBar().getVisibleAmount()) == this
+				.getVerticalScrollBar().getMaximum();
+
+		//add the new alert and update the panel to show it
+		newAlerts.add(alert);
+		updateTracePanel();
+
+		//JScrollBar bar = this.getVerticalScrollBar();
+		// bar.setValue(bar.getMaximum() + bar.getVisibleAmount());
+
+		//Should snap the trace panel to the bottom when a new thing is added (makes it so you don't have to scroll down manually as new stuff gets added in)
+		if (scrollDown) {
+			Document d = this.traceTextPane.getDocument();
+			this.traceTextPane.select(d.getLength(), d.getLength());
+			// this.getVerticalScrollBar().setValue(
+			// this.getVerticalScrollBar().getMaximum()
+			// + this.getVerticalScrollBar().getVisibleAmount());
+		}
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public void alertOccurred(Alert alert) {
+		addNewAlert(alert);
+	}
+
+}

--- a/simcity/gui/trace/TracePanel.java
+++ b/simcity/gui/trace/TracePanel.java
@@ -47,7 +47,7 @@ public class TracePanel extends JScrollPane implements AlertListener {
 
 	private List<Alert> newAlerts = Collections.synchronizedList(new ArrayList<Alert>());
 	private Set<AlertLevel> visibleLevels = Collections.synchronizedSet(EnumSet.allOf(AlertLevel.class));
-	private Set<AlertTag> visibleTags = Collections.synchronizedSet(EnumSet.allOf(AlertTag.class));
+	private Set<AlertTag> visibleTags = Collections.synchronizedSet(EnumSet.noneOf(AlertTag.class));
 
 	Dimension size;
 	Style errorStyle;
@@ -82,7 +82,9 @@ public class TracePanel extends JScrollPane implements AlertListener {
 
 		// Warning
 		StyleConstants.setForeground(warningStyle, Color.yellow);
-		StyleConstants.setBackground(warningStyle, Color.black);		//TODO: This looks ugly and is only so we could actually read the text... change it!
+		//TODO: This looks ugly and is only so we could actually read the text... change it!
+		//And maybe change font color or panel background color or something...
+		StyleConstants.setBackground(warningStyle, Color.black);
 
 		// Info
 		StyleConstants.setForeground(infoStyle, Color.blue);
@@ -166,8 +168,6 @@ public class TracePanel extends JScrollPane implements AlertListener {
 	 * Filters the trace panel according to Level and Tag and only displays those which have been enabled.
 	 */
 	private void filterTracePanel() {
-		updateTracePanel();	//update the panel to make sure we have the most recent
-
 		try {
 			traceTextPane.getStyledDocument().remove(0, traceTextPane.getStyledDocument().getLength());	//Removes the whole document
 		} catch (BadLocationException e) {
@@ -219,6 +219,22 @@ public class TracePanel extends JScrollPane implements AlertListener {
 	public void hideAlertsWithTag(AlertTag tag) {
 		this.visibleTags.remove(tag);
 		filterTracePanel();
+	}
+	
+	/**
+	 * Enables Alerts to be displayed for all Tag values in {@link AlertTag}.
+	 * Convenience method.
+	 */
+	public void showAlertsForAllTags() {
+		visibleTags = Collections.synchronizedSet(EnumSet.allOf(AlertTag.class));
+	}
+	
+	/**
+	 * Enables Alerts to be displayed for all Level values in {@link AlertLevel}.
+	 * Convenience method.
+	 */
+	public void showAlertsForAllLevels() {
+		visibleLevels = Collections.synchronizedSet(EnumSet.allOf(AlertLevel.class));
 	}
 
 	/**


### PR DESCRIPTION
This is a set of classes for an alert log and corresponding console display panel that I wrote for my factory project in CS 201.  They're handy classes, so I'd like to include them in the sample code for students.  Especially since it would otherwise be a nightmare to look through their console System.out print statements.  The TracePanel includes some color formatting, and most importantly, the ability to filter the logs (eg. only see warnings and errors, or only see bank teller role messages, etc.).  I have my own simple demo class that has some code morked as TUTORIAL for instructional purposes, and then I also incorporated it into the existing city demo.  There isn't a separate readme, but the code is well documented, and the DemoLauncher code has some marked tutorial information, so it should be fine.  I can write up a readme later if you'd like.
